### PR TITLE
don't use call buildings are already synced

### DIFF
--- a/src/main/java/CastleWars/logic/room/DrillRoom.java
+++ b/src/main/java/CastleWars/logic/room/DrillRoom.java
@@ -42,7 +42,7 @@ public class DrillRoom extends Room {
     @Override
     public void update() {
         if (buyyed && interval.get(0, 60f) && team.core() != null) {
-            team.core().items.add(ItemStack.with(Items.thorium, 4, Items.blastCompound, 4, Items.surgeAlloy, 4, Items.plastanium, 4))
+            team.core().items.add(ItemStack.with(Items.thorium, 8, Items.blastCompound, 4, Items.surgeAlloy, 4, Items.plastanium, 4))
         }
     }
 

--- a/src/main/java/CastleWars/logic/room/DrillRoom.java
+++ b/src/main/java/CastleWars/logic/room/DrillRoom.java
@@ -12,6 +12,7 @@ import mindustry.gen.Nulls;
 import mindustry.gen.Player;
 import mindustry.world.Tiles;
 import mindustry.world.blocks.environment.Floor;
+import mindustry.type.ItemStack;
 
 public class DrillRoom extends Room {
 
@@ -41,10 +42,7 @@ public class DrillRoom extends Room {
     @Override
     public void update() {
         if (buyyed && interval.get(0, 60f) && team.core() != null) {
-            Call.transferItemTo(Nulls.unit, Items.thorium, 4, drawx, drawy, team.core());
-            Call.transferItemTo(Nulls.unit, Items.blastCompound, 4, drawx, drawy, team.core());
-            Call.transferItemTo(Nulls.unit, Items.surgeAlloy, 4, drawx, drawy, team.core());
-            Call.transferItemTo(Nulls.unit, Items.plastanium, 4, drawx, drawy, team.core());
+            team.core().items.add(ItemStack.with(Items.thorium, 4, Items.blastCompound, 4, Items.surgeAlloy, 4, Items.plastanium, 4))
         }
     }
 

--- a/src/main/java/CastleWars/logic/room/TurretRoom.java
+++ b/src/main/java/CastleWars/logic/room/TurretRoom.java
@@ -79,8 +79,8 @@ public class TurretRoom extends Room {
 
     @Override
     public void update() {
-        if (buyyed && tile.build != null && interval.get(0, SEC_TIMER * 20) && item != null) {
-            if (this.tile.build instanceof Turret.TurretBuild) ((Turret.TurretBuild) this.tile.build).handleStack(this.item, Integer.MAX_VALUE, null);
+        if (buyyed && tile.build != null && item != null && this.tile.build instanceof Turret.TurretBuild && interval.get(0, SEC_TIMER * 20)) {
+            ((Turret.TurretBuild) this.tile.build).handleStack(this.item, Integer.MAX_VALUE, null);
         }
     }
 

--- a/src/main/java/CastleWars/logic/room/TurretRoom.java
+++ b/src/main/java/CastleWars/logic/room/TurretRoom.java
@@ -19,6 +19,7 @@ import mindustry.world.Tile;
 import mindustry.world.Tiles;
 import mindustry.world.blocks.environment.Floor;
 import arc.util.Interval;
+import mindustry.world.blocks.defense.turrets.Turret;
 
 public class TurretRoom extends Room {
 
@@ -78,8 +79,8 @@ public class TurretRoom extends Room {
 
     @Override
     public void update() {
-        if (buyyed && tile.build != null && interval.get(0, SEC_TIMER * 20)) {
-            Call.transferItemTo(Nulls.unit, Items.surgeAlloy, Integer.MAX_VALUE, super.drawx, super.drawy, tile.build);
+        if (buyyed && tile.build != null && interval.get(0, SEC_TIMER * 20) && item != null) {
+            if (this.tile.build instanceof Turret.TurretBuild) ((Turret.TurretBuild) this.tile.build).handleStack(this.item, Integer.MAX_VALUE, null);
         }
     }
 


### PR DESCRIPTION
use build.items to add items instead of call (turrets don't use build.items so you have to call handleItem)